### PR TITLE
Tests for OHV and OHM Related Functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# vim session
+*.vim

--- a/class.go
+++ b/class.go
@@ -112,7 +112,10 @@ func ToClasses(a tensor.Tensor, threshold float64) []Class {
 			for j := range d[i] {
 				if d[i][j] > thresh {
 					retVal[i] = Class(j)
-					continue
+					break
+				}
+				if j == len(d[i])-1 {
+					panic(fmt.Sprintf("Unreachable class in matrix at row: %d", i))
 				}
 			}
 		}
@@ -122,7 +125,10 @@ func ToClasses(a tensor.Tensor, threshold float64) []Class {
 			for j := range d[i] {
 				if d[i][j] > thresh {
 					retVal[i] = Class(j)
-					continue
+					break
+				}
+				if j == len(d[i])-1 {
+					panic(fmt.Sprintf("Unreachable class in matrix at row: %d", i))
 				}
 			}
 		}
@@ -131,7 +137,10 @@ func ToClasses(a tensor.Tensor, threshold float64) []Class {
 			for j := range d[i] {
 				if d[i][j] >= 1 {
 					retVal[i] = Class(j)
-					continue
+					break
+				}
+				if j == len(d[i])-1 {
+					panic(fmt.Sprintf("Unreachable class in matrix at row: %d", i))
 				}
 			}
 		}
@@ -140,7 +149,10 @@ func ToClasses(a tensor.Tensor, threshold float64) []Class {
 			for j := range d[i] {
 				if d[i][j] >= 1 {
 					retVal[i] = Class(j)
-					continue
+					break
+				}
+				if j == len(d[i])-1 {
+					panic(fmt.Sprintf("Unreachable class in matrix at row: %d", i))
 				}
 			}
 		}

--- a/class.go
+++ b/class.go
@@ -233,23 +233,20 @@ func UnsafeToOneHotMatrix(a []Class, numClasses uint, reuse *tensor.Dense) *tens
 	reuse.Zero()
 	var err error
 	// Handline shapes of [1, numClasses]
-	if len(a) == 1 {
+	if reuse.IsRowVec() {
 		switch dt {
 		case tensor.Float32:
-			err = reuse.SetAt(float32(1), 0, int(a[0])-1)
+			reuse.Set(int(a[0]), float32(1))
 		case tensor.Float64:
-			err = reuse.SetAt(float64(1), int(a[0]))
+			reuse.Set(int(a[0]), float64(1))
 		case tensor.Int64:
-			err = reuse.SetAt(int64(1), int(a[0]))
+			reuse.Set(int(a[0]), int64(1))
 		case tensor.Int:
-			err = reuse.SetAt(int(1), int(a[0]))
+			reuse.Set(int(a[0]), int(1))
 		case tensor.Int32:
-			err = reuse.SetAt(int32(1), int(a[0]))
+			reuse.Set(int(a[0]), int32(1))
 		default:
 			panic(fmt.Sprintf("UnsafeToOneHotVector not implemented for %v", dt))
-		}
-		if err != nil {
-			panic(err.Error())
 		}
 		return reuse
 	}

--- a/class_test.go
+++ b/class_test.go
@@ -1,0 +1,59 @@
+package qol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gorgonia.org/tensor"
+)
+
+func TestToClass(t *testing.T) {
+	// TODO: panic without an iterator
+	// Test panic on non vector
+	panicOnNonVector := func() {
+		_ = ToClass(tensor.New(tensor.Of(tensor.Float32), tensor.WithShape(10, 10)), 0)
+	}
+	assert.Panics(t, panicOnNonVector)
+	// Panic on unsupported tensor dtype
+	panicOnUnsupportedType := func() {
+		_ = ToClass(tensor.New(tensor.Of(tensor.Complex64), tensor.WithShape(10)), 0)
+	}
+	assert.Panics(t, panicOnUnsupportedType)
+
+	// // Float32
+	// dataFloat32 := []float32{0, 0, 1, 0, 0}
+	// resultFloat32 := ToClass(tensor.New(tensor.WithBacking(dataFloat32)), 0)
+	// assert.Equal(t, resultFloat32, Class(2))
+
+	// dataFloat64 := []float64{0, 1, 2, 3, 4}
+	// t.Log(ToClass(tensor.New(tensor.WithBacking(dataFloat64)), 0))
+
+	// dataInt := []int{0, 1, 2, 3, 4}
+	// t.Log(ToClass(tensor.New(tensor.WithBacking(dataInt)), 0))
+
+	// dataUint := []uint{0, 1, 2, 3, 4}
+	// t.Log(ToClass(tensor.New(tensor.WithBacking(dataUint)), 0))
+}
+
+func TestToClasses(t *testing.T) {
+	// Not Implemented
+}
+
+func TestToOneHotVector(t *testing.T) {
+	// Not Implemented
+}
+
+func TestToOneHotMatrix(t *testing.T) {
+
+	// Not Implemented
+}
+
+func TestUnsafeToOneHotVector(t *testing.T) {
+
+	// Not Implemented
+}
+
+func TestUnsafeToOneHotMatrix(t *testing.T) {
+
+	// Not Implemented
+}

--- a/class_test.go
+++ b/class_test.go
@@ -21,28 +21,28 @@ func TestToClass(t *testing.T) {
 	// Value Tests
 	// only specifying vectors of length 5 varying values, type, and threshold
 	// Float32
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]float32{0, 0, 1, 0, 0})), 0), Class(2))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]float32{0.1, 0.1, 0.6, 0.7, 0.1})), 0), Class(2))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]float32{0.1, 0.1, 0.6, 0.7, 0.1})), 0.65), Class(3))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]float32{1, 1, 1, 1, 1})), 0), Class(0))
-	// Float64
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]float64{0, 0, 1, 0, 0})), 0), Class(2))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]float64{0.1, 0.1, 0.6, 0.7, 0.1})), 0), Class(2))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]float64{0.1, 0.1, 0.6, 0.7, 0.1})), 0.65), Class(3))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]float64{1, 1, 1, 1, 1})), 0), Class(0))
-	// Int
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]int{0, 0, 1, 0, 0})), 0), Class(2))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]int{0, 0, 1, 0, 0})), 999), Class(2))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]int{0, 0, 2, 0, 0})), 0), Class(2))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]int{0, 1, 2, 0, 0})), 0), Class(1))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]int{1, 1, 1, 1, 1})), 0), Class(0))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]int{-1, -2, -3, 0, 1})), 0), Class(4))
-	// uint
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]uint{0, 0, 1, 0, 0})), 0), Class(2))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]uint{0, 0, 1, 0, 0})), 999), Class(2))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]uint{0, 0, 2, 0, 0})), 0), Class(2))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]uint{0, 1, 2, 0, 0})), 0), Class(1))
-	assert.Equal(t, ToClass(T.New(T.WithBacking([]uint{1, 1, 1, 1, 1})), 0), Class(0))
+	assert.Equal(t, Class(2), ToClass(T.New(T.WithBacking([]float32{0, 0, 1, 0, 0})), 0))
+	assert.Equal(t, Class(2), ToClass(T.New(T.WithBacking([]float32{0.1, 0.1, 0.6, 0.7, 0.1})), 0))
+	assert.Equal(t, Class(3), ToClass(T.New(T.WithBacking([]float32{0.1, 0.1, 0.6, 0.7, 0.1})), 0.65))
+	assert.Equal(t, Class(0), ToClass(T.New(T.WithBacking([]float32{1, 1, 1, 1, 1})), 0))
+	// lFat64
+	assert.Equal(t, Class(2), ToClass(T.New(T.WithBacking([]float64{0, 0, 1, 0, 0})), 0))
+	assert.Equal(t, Class(2), ToClass(T.New(T.WithBacking([]float64{0.1, 0.1, 0.6, 0.7, 0.1})), 0))
+	assert.Equal(t, Class(3), ToClass(T.New(T.WithBacking([]float64{0.1, 0.1, 0.6, 0.7, 0.1})), 0.65))
+	assert.Equal(t, Class(0), ToClass(T.New(T.WithBacking([]float64{1, 1, 1, 1, 1})), 0))
+	// nI
+	assert.Equal(t, Class(2), ToClass(T.New(T.WithBacking([]int{0, 0, 1, 0, 0})), 0))
+	assert.Equal(t, Class(2), ToClass(T.New(T.WithBacking([]int{0, 0, 1, 0, 0})), 999))
+	assert.Equal(t, Class(2), ToClass(T.New(T.WithBacking([]int{0, 0, 2, 0, 0})), 0))
+	assert.Equal(t, Class(1), ToClass(T.New(T.WithBacking([]int{0, 1, 2, 0, 0})), 0))
+	assert.Equal(t, Class(0), ToClass(T.New(T.WithBacking([]int{1, 1, 1, 1, 1})), 0))
+	assert.Equal(t, Class(4), ToClass(T.New(T.WithBacking([]int{-1, -2, -3, 0, 1})), 0))
+	// iut
+	assert.Equal(t, Class(2), ToClass(T.New(T.WithBacking([]uint{0, 0, 1, 0, 0})), 0))
+	assert.Equal(t, Class(2), ToClass(T.New(T.WithBacking([]uint{0, 0, 1, 0, 0})), 999))
+	assert.Equal(t, Class(2), ToClass(T.New(T.WithBacking([]uint{0, 0, 2, 0, 0})), 0))
+	assert.Equal(t, Class(1), ToClass(T.New(T.WithBacking([]uint{0, 1, 2, 0, 0})), 0))
+	assert.Equal(t, Class(0), ToClass(T.New(T.WithBacking([]uint{1, 1, 1, 1, 1})), 0))
 }
 
 func TestToClasses(t *testing.T) {
@@ -62,72 +62,73 @@ func TestToClasses(t *testing.T) {
 	// Float32
 	// chewxy testcase
 	matF32 = T.New(T.WithBacking([]float32{0.1, 0.1, 0.6, 0.7, 0.1, 0.6, 0.1, 0.1, 0.7, 0.1}), T.WithShape(2, 5))
-	assert.Equal(t, ToClasses(matF32, 0), []Class{2, 0})
+	assert.Equal(t, []Class{2, 0}, ToClasses(matF32, 0))
 
 	matF32 = T.New(T.WithBacking([]float32{0, 0, 1, 0, 1, 0}), shp)
-	assert.Equal(t, ToClasses(matF32, 0), []Class{2, 1})
+	assert.Equal(t, []Class{2, 1}, ToClasses(matF32, 0))
 
 	matF32 = T.New(T.WithBacking([]float32{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp)
-	assert.Equal(t, ToClasses(matF32, 0), []Class{1, 1})
+	assert.Equal(t, []Class{1, 1}, ToClasses(matF32, 0))
 
 	matF32 = T.New(T.WithBacking([]float32{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp)
-	assert.Equal(t, ToClasses(matF32, 0.65), []Class{2, 1})
+	assert.Equal(t, []Class{2, 1}, ToClasses(matF32, 0.65))
 
 	matF32 = T.New(T.WithBacking([]float32{0.1, -1, 0.7, -1.0, 0.2, 0.6}), shp)
-	assert.Equal(t, ToClasses(matF32, 0), []Class{2, 2})
+	assert.Equal(t, []Class{2, 2}, ToClasses(matF32, 0))
 
 	matF32 = T.New(T.WithBacking([]float32{1, 1, 1, 1, 1, 1}), shp)
-	assert.Equal(t, ToClasses(matF32, 0), []Class{0, 0})
+	assert.Equal(t, []Class{0, 0}, ToClasses(matF32, 0))
 
 	// Float64
 	// chewxy testcase
 	matF64 = T.New(T.WithBacking([]float64{0.1, 0.1, 0.6, 0.7, 0.1, 0.6, 0.1, 0.1, 0.7, 0.1}), T.WithShape(2, 5))
-	assert.Equal(t, ToClasses(matF64, 0), []Class{2, 0})
+	assert.Equal(t, []Class{2, 0}, ToClasses(matF64, 0))
 
 	matF64 = T.New(T.WithBacking([]float64{0, 0, 1, 0, 1, 0}), shp)
-	assert.Equal(t, ToClasses(matF64, 0), []Class{2, 1})
+	assert.Equal(t, []Class{2, 1}, ToClasses(matF64, 0))
 
 	matF64 = T.New(T.WithBacking([]float64{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp)
-	assert.Equal(t, ToClasses(matF64, 0), []Class{1, 1})
+	assert.Equal(t, []Class{1, 1}, ToClasses(matF64, 0))
 
 	matF64 = T.New(T.WithBacking([]float64{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp)
-	assert.Equal(t, ToClasses(matF64, 0.65), []Class{2, 1})
+	assert.Equal(t, []Class{2, 1}, ToClasses(matF64, 0.65))
 
 	matF64 = T.New(T.WithBacking([]float64{0.1, -1, 0.7, -1.0, 0.2, 0.6}), shp)
-	assert.Equal(t, ToClasses(matF64, 0), []Class{2, 2})
+	assert.Equal(t, []Class{2, 2}, ToClasses(matF64, 0))
 
 	matF64 = T.New(T.WithBacking([]float64{1, 1, 1, 1, 1, 1}), shp)
-	assert.Equal(t, ToClasses(matF64, 0), []Class{0, 0})
+	assert.Equal(t, []Class{0, 0}, ToClasses(matF64, 0))
 
 	// Int
 	matInt = T.New(T.WithBacking([]int{0, 0, 1, 0, 1, 0}), shp)
-	assert.Equal(t, ToClasses(matInt, 0), []Class{2, 1})
+	assert.Equal(t, []Class{2, 1}, ToClasses(matInt, 0))
 
 	matInt = T.New(T.WithBacking([]int{0, 0, 1, 0, 1, 0}), shp)
-	assert.Equal(t, ToClasses(matInt, 999), []Class{2, 1})
+	assert.Equal(t, []Class{2, 1}, ToClasses(matInt, 999))
 
 	matInt = T.New(T.WithBacking([]int{0, 0, 2, 1, 2, 0}), shp)
-	assert.Equal(t, ToClasses(matInt, 0), []Class{2, 0})
+	assert.Equal(t, []Class{2, 0}, ToClasses(matInt, 0))
 
 	matInt = T.New(T.WithBacking([]int{1, 1, 1, 1, 1, 1}), shp)
-	assert.Equal(t, ToClasses(matInt, 0), []Class{0, 0})
+	assert.Equal(t, []Class{0, 0}, ToClasses(matInt, 0))
 
 	matInt = T.New(T.WithBacking([]int{-1, 1, -2, -3, 0, 1}), shp)
-	assert.Equal(t, ToClasses(matInt, 0), []Class{1, 2})
+	assert.Equal(t, []Class{1, 2}, ToClasses(matInt, 0))
 
 	// Uint
 	matUint = T.New(T.WithBacking([]uint{0, 0, 1, 0, 1, 0}), shp)
-	assert.Equal(t, ToClasses(matUint, 0), []Class{2, 1})
+	assert.Equal(t, []Class{2, 1}, ToClasses(matUint, 0))
 
 	matUint = T.New(T.WithBacking([]uint{0, 0, 1, 0, 1, 0}), shp)
-	assert.Equal(t, ToClasses(matUint, 999), []Class{2, 1})
+	assert.Equal(t, []Class{2, 1}, ToClasses(matUint, 999))
 
 	matUint = T.New(T.WithBacking([]uint{0, 0, 2, 1, 2, 0}), shp)
-	assert.Equal(t, ToClasses(matUint, 0), []Class{2, 0})
+	assert.Equal(t, []Class{2, 0}, ToClasses(matUint, 0))
 
 	matUint = T.New(T.WithBacking([]uint{1, 1, 1, 1, 1, 1}), shp)
-	assert.Equal(t, ToClasses(matUint, 0), []Class{0, 0})
+	assert.Equal(t, []Class{0, 0}, ToClasses(matUint, 0))
 }
+
 func NewToOneHotVectorSuite(unsafe bool, a Class, numClasses uint, backingActual, backingExpected interface{}) *ToOneHotVectorSuite {
 	shp := T.WithShape(int(numClasses))
 	return &ToOneHotVectorSuite{
@@ -158,13 +159,13 @@ func (suite *ToOneHotVectorSuite) Test() {
 		oh = ToOneHotVector(suite.a, suite.numClasses, suite.reuse.Dtype())
 	}
 	// Check data and shape between expected and resulting of UnsafeToOneHotVector
-	assert.Equal(suite.T(), oh.Data(), suite.expected.Data())
-	assert.Equal(suite.T(), oh.Shape(), suite.expected.Shape())
+	assert.Equal(suite.T(), suite.expected.Data(), oh.Data())
+	assert.Equal(suite.T(), suite.expected.Shape(), oh.Shape())
 	if suite.unsafe {
 		// Check if the operation is infact unsafe
-		assert.Equal(suite.T(), suite.reuse.Data(), suite.expected.Data())
-		assert.Equal(suite.T(), suite.reuse.Shape(), suite.expected.Shape())
-		assert.Equal(suite.T(), &oh, &suite.reuse)
+		assert.Equal(suite.T(), suite.expected.Data(), suite.reuse.Data())
+		assert.Equal(suite.T(), suite.expected.Shape(), suite.reuse.Shape())
+		assert.Equal(suite.T(), &suite.reuse, &oh)
 	}
 }
 
@@ -266,11 +267,50 @@ func TestToOneHotVectorSuite(t *testing.T) {
 	suite.Run(t, NewToOneHotVectorSuite(true, 3, 5, []int{0, 0, 0, 0, 0}, []int{0, 0, 0, 1, 0}))
 }
 
+func NewToOneHotMatrixSuite(unsafe bool, a []Class, numClasses uint, backingActual, backingExpected interface{}, shp T.Shape) *ToOneHotMatrixSuite {
+	return &ToOneHotMatrixSuite{
+		unsafe:     unsafe,
+		a:          a,
+		numClasses: numClasses,
+		reuse:      T.New(T.WithBacking(backingActual), T.WithShape(shp...)),
+		expected:   T.New(T.WithBacking(backingExpected), T.WithShape(shp...)),
+	}
+}
+
+// ToOneHotMatrixSuite test both the safe and unsafe version and the
+// ToOneHotMatrix by specifying the `unsafe` boolean flag
+type ToOneHotMatrixSuite struct {
+	suite.Suite
+	unsafe          bool
+	a               []Class
+	numClasses      uint
+	reuse, expected *T.Dense
+}
+
+func (suite *ToOneHotMatrixSuite) Test() {
+	// Safe or unsafe function
+	var oh *T.Dense
+	if suite.unsafe {
+		oh = UnsafeToOneHotMatrix(suite.a, suite.numClasses, suite.reuse)
+	} else {
+		oh = ToOneHotMatrix(suite.a, suite.numClasses, suite.reuse.Dtype())
+	}
+	// Check data and shape between expected and resulting of UnsafeToOneHotMatrix
+	assert.Equal(suite.T(), suite.expected.Data(), oh.Data())
+	assert.Equal(suite.T(), suite.expected.Shape(), oh.Shape())
+	if suite.unsafe {
+		// Check if the operation is infact unsafe
+		assert.Equal(suite.T(), suite.reuse.Data(), suite.expected.Data())
+		assert.Equal(suite.T(), suite.reuse.Shape(), suite.expected.Shape())
+		assert.Equal(suite.T(), &oh, &suite.reuse)
+	}
+}
+
 func TestToOneHotMatrix(t *testing.T) {
 	// Not Implemented
 }
 
 func TestUnsafeToOneHotMatrix(t *testing.T) {
-
-	// Not Implemented
+	// suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1}, 5, []float32{0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0}, []int{1, 5}))
+	// suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1, 1}, 5, []float32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0, 0, 1, 0, 0, 0}, []int{2, 5}))
 }

--- a/class_test.go
+++ b/class_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 	"gorgonia.org/tensor"
 	T "gorgonia.org/tensor"
 )
@@ -129,17 +130,145 @@ func TestToClasses(t *testing.T) {
 }
 
 func TestToOneHotVector(t *testing.T) {
-	// Not Implemented
+	// Panics
+	// n classes not the same as vector length
+	assert.Panics(t, func() { UnsafeToOneHotVector(0, 999, T.New(T.Of(T.Float32), T.WithShape(5))) })
+	assert.Panics(t, func() { UnsafeToOneHotVector(0, 2, T.New(T.Of(T.Float32), T.WithShape(5))) })
+	assert.NotPanics(t, func() { UnsafeToOneHotVector(0, 5, T.New(T.Of(T.Float32), T.WithShape(5))) })
+	// Class is out of range
+	assert.Panics(t, func() { UnsafeToOneHotVector(10, 5, T.New(T.Of(T.Float32), T.WithShape(5))) })
+	assert.Panics(t, func() { UnsafeToOneHotVector(5, 5, T.New(T.Of(T.Float32), T.WithShape(5))) })
+	assert.NotPanics(t, func() { UnsafeToOneHotVector(0, 5, T.New(T.Of(T.Float32), T.WithShape(5))) })
+	// Non Vector
+	assert.Panics(t, func() { UnsafeToOneHotVector(0, 5, T.New(T.Of(T.Float32), T.WithShape(5, 5))) })
+	assert.Panics(t, func() { UnsafeToOneHotVector(0, 5, T.New(T.Of(T.Float32), T.WithShape(1, 5))) })
+	// Unsupported type
+	assert.Panics(t, func() { UnsafeToOneHotVector(0, 5, T.New(T.Of(T.Complex64), T.WithShape(5))) })
+
+	// Value tests
+	// Float32
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []float32{0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []float32{1, 1, 1, 1, 1}, []float32{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []float32{1, 1, 1, 1, 1}, []float32{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 3, []float32{0, 0, 0}, []float32{0, 1, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 3, 5, []float32{0, 0, 0, 0, 0}, []float32{0, 0, 0, 1, 0}))
+	// Float64
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []float64{0, 0, 0, 0, 0}, []float64{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []float64{1, 1, 1, 1, 1}, []float64{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []float64{1, 1, 1, 1, 1}, []float64{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 3, []float64{0, 0, 0}, []float64{0, 1, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 3, 5, []float64{0, 0, 0, 0, 0}, []float64{0, 0, 0, 1, 0}))
+	// Int32
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int32{0, 0, 0, 0, 0}, []int32{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int32{1, 1, 1, 1, 1}, []int32{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int32{1, 1, 1, 1, 1}, []int32{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 3, []int32{0, 0, 0}, []int32{0, 1, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 3, 5, []int32{0, 0, 0, 0, 0}, []int32{0, 0, 0, 1, 0}))
+	// Int64
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int64{0, 0, 0, 0, 0}, []int64{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int64{1, 1, 1, 1, 1}, []int64{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int64{1, 1, 1, 1, 1}, []int64{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 3, []int64{0, 0, 0}, []int64{0, 1, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 3, 5, []int64{0, 0, 0, 0, 0}, []int64{0, 0, 0, 1, 0}))
+	// Int
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int{0, 0, 0, 0, 0}, []int{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int{1, 1, 1, 1, 1}, []int{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int{1, 1, 1, 1, 1}, []int{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 1, 3, []int{0, 0, 0}, []int{0, 1, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(false, 3, 5, []int{0, 0, 0, 0, 0}, []int{0, 0, 0, 1, 0}))
 }
 
 func TestToOneHotMatrix(t *testing.T) {
-
 	// Not Implemented
 }
 
-func TestUnsafeToOneHotVector(t *testing.T) {
+func NewToOneHotVectorSuite(unsafe bool, a Class, numClasses uint, backingActual, backingExpected interface{}) *ToOneHotVectorSuite {
+	shp := T.WithShape(int(numClasses))
+	return &ToOneHotVectorSuite{
+		unsafe:     unsafe,
+		a:          a,
+		numClasses: numClasses,
+		reuse:      T.New(T.WithBacking(backingActual), shp),
+		expected:   T.New(T.WithBacking(backingExpected), shp),
+	}
+}
 
-	// Not Implemented
+// ToOneHotVectorSuite test both the safe and unsafe version and the
+// ToOneHotVector by specifying the `unsafe` boolean flag
+type ToOneHotVectorSuite struct {
+	suite.Suite
+	unsafe          bool
+	a               Class
+	numClasses      uint
+	reuse, expected *T.Dense
+}
+
+func (suite *ToOneHotVectorSuite) Test() {
+	// Safe or unsafe function
+	var oh *T.Dense
+	if suite.unsafe {
+		oh = UnsafeToOneHotVector(suite.a, suite.numClasses, suite.reuse)
+	} else {
+		oh = ToOneHotVector(suite.a, suite.numClasses, suite.reuse.Dtype())
+	}
+	// Check data and shape between expected and resulting of UnsafeToOneHotVector
+	assert.Equal(suite.T(), oh.Data(), suite.expected.Data())
+	assert.Equal(suite.T(), oh.Shape(), suite.expected.Shape())
+	if suite.unsafe {
+		// Check if the operation is infact unsafe
+		assert.Equal(suite.T(), suite.reuse.Data(), suite.expected.Data())
+		assert.Equal(suite.T(), suite.reuse.Shape(), suite.expected.Shape())
+		assert.Equal(suite.T(), &oh, &suite.reuse)
+	}
+}
+
+func TestToOneHotVectorSuite(t *testing.T) {
+	// Panics
+	// n classes not the same as vector length
+	assert.Panics(t, func() { UnsafeToOneHotVector(0, 999, T.New(T.Of(T.Float32), T.WithShape(5))) })
+	assert.Panics(t, func() { UnsafeToOneHotVector(0, 2, T.New(T.Of(T.Float32), T.WithShape(5))) })
+	assert.NotPanics(t, func() { UnsafeToOneHotVector(0, 5, T.New(T.Of(T.Float32), T.WithShape(5))) })
+	// Class is out of range
+	assert.Panics(t, func() { UnsafeToOneHotVector(10, 5, T.New(T.Of(T.Float32), T.WithShape(5))) })
+	assert.Panics(t, func() { UnsafeToOneHotVector(5, 5, T.New(T.Of(T.Float32), T.WithShape(5))) })
+	assert.NotPanics(t, func() { UnsafeToOneHotVector(0, 5, T.New(T.Of(T.Float32), T.WithShape(5))) })
+	// Non Vector
+	assert.Panics(t, func() { UnsafeToOneHotVector(0, 5, T.New(T.Of(T.Float32), T.WithShape(5, 5))) })
+	assert.Panics(t, func() { UnsafeToOneHotVector(0, 5, T.New(T.Of(T.Float32), T.WithShape(1, 5))) })
+	// Unsupported type
+	assert.Panics(t, func() { UnsafeToOneHotVector(0, 5, T.New(T.Of(T.Complex64), T.WithShape(5))) })
+
+	// Value tests
+	// Float32
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []float32{0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []float32{1, 1, 1, 1, 1}, []float32{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []float32{1, 1, 1, 1, 1}, []float32{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 3, []float32{0, 0, 0}, []float32{0, 1, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 3, 5, []float32{0, 0, 0, 0, 0}, []float32{0, 0, 0, 1, 0}))
+	// Float64
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []float64{0, 0, 0, 0, 0}, []float64{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []float64{1, 1, 1, 1, 1}, []float64{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []float64{1, 1, 1, 1, 1}, []float64{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 3, []float64{0, 0, 0}, []float64{0, 1, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 3, 5, []float64{0, 0, 0, 0, 0}, []float64{0, 0, 0, 1, 0}))
+	// Int32
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []int32{0, 0, 0, 0, 0}, []int32{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []int32{1, 1, 1, 1, 1}, []int32{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []int32{1, 1, 1, 1, 1}, []int32{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 3, []int32{0, 0, 0}, []int32{0, 1, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 3, 5, []int32{0, 0, 0, 0, 0}, []int32{0, 0, 0, 1, 0}))
+	// Int64
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []int64{0, 0, 0, 0, 0}, []int64{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []int64{1, 1, 1, 1, 1}, []int64{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []int64{1, 1, 1, 1, 1}, []int64{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 3, []int64{0, 0, 0}, []int64{0, 1, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 3, 5, []int64{0, 0, 0, 0, 0}, []int64{0, 0, 0, 1, 0}))
+	// Int
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []int{0, 0, 0, 0, 0}, []int{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []int{1, 1, 1, 1, 1}, []int{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 5, []int{1, 1, 1, 1, 1}, []int{0, 1, 0, 0, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 1, 3, []int{0, 0, 0}, []int{0, 1, 0}))
+	suite.Run(t, NewToOneHotVectorSuite(true, 3, 5, []int{0, 0, 0, 0, 0}, []int{0, 0, 0, 1, 0}))
 }
 
 func TestUnsafeToOneHotMatrix(t *testing.T) {

--- a/class_test.go
+++ b/class_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gorgonia.org/tensor"
 	T "gorgonia.org/tensor"
 )
 
 func TestToClass(t *testing.T) {
+	// Panic Tests
 	// TODO: panic without an iterator
 	// Test panic on non vector
 	assert.Panics(t, func() { ToClass(T.New(T.Of(T.Float32), T.WithShape(10, 10)), 0) })
@@ -15,8 +17,8 @@ func TestToClass(t *testing.T) {
 	assert.Panics(t, func() { ToClass(T.New(T.Of(T.Complex64), T.WithShape(10)), 0) })
 	// Panic on Unreachable
 	assert.Panics(t, func() { ToClass(T.New(T.WithBacking([]float32{0, 0, 1, 0, 0})), 999) })
-
-	// From here on only specifying vectors of length 5 varying type and threshold
+	// Value Tests
+	// only specifying vectors of length 5 varying values, type, and threshold
 	// Float32
 	assert.Equal(t, ToClass(T.New(T.WithBacking([]float32{0, 0, 1, 0, 0})), 0), Class(2))
 	assert.Equal(t, ToClass(T.New(T.WithBacking([]float32{0.1, 0.1, 0.6, 0.7, 0.1})), 0), Class(2))
@@ -43,14 +45,33 @@ func TestToClass(t *testing.T) {
 }
 
 func TestToClasses(t *testing.T) {
+	// Panic Tests
 	// TODO: panic without an iterator
 	// Test panic on non matrix
-	assert.Panics(t, func() { ToClass(T.New(T.Of(T.Float32), T.WithShape(10)), 0) })
-	assert.Panics(t, func() { ToClass(T.New(T.Of(T.Float32), T.WithShape(10, 10, 10)), 0) })
+	assert.Panics(t, func() { ToClasses(T.New(T.Of(T.Float32), T.WithShape(10)), 0) })
+	assert.Panics(t, func() { ToClasses(T.New(T.Of(T.Float32), T.WithShape(10, 10, 10)), 0) })
 	// Panic on unsupported T dtype
-	assert.Panics(t, func() { ToClass(T.New(T.Of(T.Complex64), T.WithShape(10)), 0) })
+	assert.Panics(t, func() { ToClasses(T.New(T.Of(T.Complex64), T.WithShape(10)), 0) })
 	// Panic on Unreachable
-	assert.Panics(t, func() { ToClass(T.New(T.WithBacking([][]float32{{0, 0, 1}, {0, 0, 1}})), 999) })
+	assert.Panics(t, func() { ToClasses(T.New(T.WithBacking([][]float32{{0, 0, 1}, {0, 0, 1}})), 999) })
+	// Value Tests
+	// only specifying matracies of length 2x3 varying values, type, and threshold
+	var matF32, matF64, matInt, matUint tensor.Tensor
+	// Float32
+	// []float32{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}
+	// []float32{0.1, 0.6, 0.7, -1.0, 0.2, 0.6}
+	// []float32{0.1, 0.6, 0.7, -1.0, 0.2, 0.6}
+	matF32 = T.New(T.WithBacking([]float32{0, 0, 1, 0, 1, 0}), T.WithShape(2, 3))
+	assert.Equal(t, ToClasses(matF32, 0), []Class{2, 1})
+	// Float64
+	matF64 = T.New(T.WithBacking([]float64{0, 0, 1, 0, 1, 0}), T.WithShape(2, 3))
+	assert.Equal(t, ToClasses(matF64, 0), []Class{2, 1})
+	// Int
+	matInt = T.New(T.WithBacking([]int{0, 0, 1, 0, 1, 0}), T.WithShape(2, 3))
+	assert.Equal(t, ToClasses(matInt, 0), []Class{2, 1})
+	// Uint
+	matUint = T.New(T.WithBacking([]uint{0, 0, 1, 0, 1, 0}), T.WithShape(2, 3))
+	assert.Equal(t, ToClasses(matUint, 0), []Class{2, 1})
 }
 
 func TestToOneHotVector(t *testing.T) {

--- a/class_test.go
+++ b/class_test.go
@@ -311,6 +311,6 @@ func TestToOneHotMatrix(t *testing.T) {
 }
 
 func TestUnsafeToOneHotMatrix(t *testing.T) {
-	// suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1}, 5, []float32{0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0}, []int{1, 5}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1}, 5, []float32{0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0}, []int{1, 5}))
 	// suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1, 1}, 5, []float32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0, 0, 1, 0, 0, 0}, []int{2, 5}))
 }

--- a/class_test.go
+++ b/class_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"gorgonia.org/tensor"
 	T "gorgonia.org/tensor"
 )
 
@@ -57,76 +56,34 @@ func TestToClasses(t *testing.T) {
 	assert.Panics(t, func() { ToClasses(T.New(T.WithBacking([]float32{0, 0, 1, 0, 0, 1}), T.WithShape(2, 3)), 999) })
 	// Value Tests
 	// only specifying matracies of length 2x3 varying values, type, and threshold
-	var matF32, matF64, matInt, matUint tensor.Tensor
 	shp := T.WithShape(2, 3)
 	// Float32
 	// chewxy testcase
-	matF32 = T.New(T.WithBacking([]float32{0.1, 0.1, 0.6, 0.7, 0.1, 0.6, 0.1, 0.1, 0.7, 0.1}), T.WithShape(2, 5))
-	assert.Equal(t, []Class{2, 0}, ToClasses(matF32, 0))
-
-	matF32 = T.New(T.WithBacking([]float32{0, 0, 1, 0, 1, 0}), shp)
-	assert.Equal(t, []Class{2, 1}, ToClasses(matF32, 0))
-
-	matF32 = T.New(T.WithBacking([]float32{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp)
-	assert.Equal(t, []Class{1, 1}, ToClasses(matF32, 0))
-
-	matF32 = T.New(T.WithBacking([]float32{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp)
-	assert.Equal(t, []Class{2, 1}, ToClasses(matF32, 0.65))
-
-	matF32 = T.New(T.WithBacking([]float32{0.1, -1, 0.7, -1.0, 0.2, 0.6}), shp)
-	assert.Equal(t, []Class{2, 2}, ToClasses(matF32, 0))
-
-	matF32 = T.New(T.WithBacking([]float32{1, 1, 1, 1, 1, 1}), shp)
-	assert.Equal(t, []Class{0, 0}, ToClasses(matF32, 0))
-
+	assert.Equal(t, []Class{2, 0}, ToClasses(T.New(T.WithBacking([]float32{0.1, 0.1, 0.6, 0.7, 0.1, 0.6, 0.1, 0.1, 0.7, 0.1}), T.WithShape(2, 5)), 0))
+	assert.Equal(t, []Class{2, 1}, ToClasses(T.New(T.WithBacking([]float32{0, 0, 1, 0, 1, 0}), shp), 0))
+	assert.Equal(t, []Class{1, 1}, ToClasses(T.New(T.WithBacking([]float32{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp), 0))
+	assert.Equal(t, []Class{2, 1}, ToClasses(T.New(T.WithBacking([]float32{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp), 0.65))
+	assert.Equal(t, []Class{2, 2}, ToClasses(T.New(T.WithBacking([]float32{0.1, -1, 0.7, -1.0, 0.2, 0.6}), shp), 0))
+	assert.Equal(t, []Class{0, 0}, ToClasses(T.New(T.WithBacking([]float32{1, 1, 1, 1, 1, 1}), shp), 0))
 	// Float64
 	// chewxy testcase
-	matF64 = T.New(T.WithBacking([]float64{0.1, 0.1, 0.6, 0.7, 0.1, 0.6, 0.1, 0.1, 0.7, 0.1}), T.WithShape(2, 5))
-	assert.Equal(t, []Class{2, 0}, ToClasses(matF64, 0))
-
-	matF64 = T.New(T.WithBacking([]float64{0, 0, 1, 0, 1, 0}), shp)
-	assert.Equal(t, []Class{2, 1}, ToClasses(matF64, 0))
-
-	matF64 = T.New(T.WithBacking([]float64{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp)
-	assert.Equal(t, []Class{1, 1}, ToClasses(matF64, 0))
-
-	matF64 = T.New(T.WithBacking([]float64{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp)
-	assert.Equal(t, []Class{2, 1}, ToClasses(matF64, 0.65))
-
-	matF64 = T.New(T.WithBacking([]float64{0.1, -1, 0.7, -1.0, 0.2, 0.6}), shp)
-	assert.Equal(t, []Class{2, 2}, ToClasses(matF64, 0))
-
-	matF64 = T.New(T.WithBacking([]float64{1, 1, 1, 1, 1, 1}), shp)
-	assert.Equal(t, []Class{0, 0}, ToClasses(matF64, 0))
-
+	assert.Equal(t, []Class{2, 0}, ToClasses(T.New(T.WithBacking([]float64{0.1, 0.1, 0.6, 0.7, 0.1, 0.6, 0.1, 0.1, 0.7, 0.1}), T.WithShape(2, 5)), 0))
+	assert.Equal(t, []Class{2, 1}, ToClasses(T.New(T.WithBacking([]float64{0, 0, 1, 0, 1, 0}), shp), 0))
+	assert.Equal(t, []Class{1, 1}, ToClasses(T.New(T.WithBacking([]float64{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp), 0))
+	assert.Equal(t, []Class{2, 1}, ToClasses(T.New(T.WithBacking([]float64{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp), 0.65))
+	assert.Equal(t, []Class{2, 2}, ToClasses(T.New(T.WithBacking([]float64{0.1, -1, 0.7, -1.0, 0.2, 0.6}), shp), 0))
+	assert.Equal(t, []Class{0, 0}, ToClasses(T.New(T.WithBacking([]float64{1, 1, 1, 1, 1, 1}), shp), 0))
 	// Int
-	matInt = T.New(T.WithBacking([]int{0, 0, 1, 0, 1, 0}), shp)
-	assert.Equal(t, []Class{2, 1}, ToClasses(matInt, 0))
-
-	matInt = T.New(T.WithBacking([]int{0, 0, 1, 0, 1, 0}), shp)
-	assert.Equal(t, []Class{2, 1}, ToClasses(matInt, 999))
-
-	matInt = T.New(T.WithBacking([]int{0, 0, 2, 1, 2, 0}), shp)
-	assert.Equal(t, []Class{2, 0}, ToClasses(matInt, 0))
-
-	matInt = T.New(T.WithBacking([]int{1, 1, 1, 1, 1, 1}), shp)
-	assert.Equal(t, []Class{0, 0}, ToClasses(matInt, 0))
-
-	matInt = T.New(T.WithBacking([]int{-1, 1, -2, -3, 0, 1}), shp)
-	assert.Equal(t, []Class{1, 2}, ToClasses(matInt, 0))
-
+	assert.Equal(t, []Class{2, 1}, ToClasses(T.New(T.WithBacking([]int{0, 0, 1, 0, 1, 0}), shp), 0))
+	assert.Equal(t, []Class{2, 1}, ToClasses(T.New(T.WithBacking([]int{0, 0, 1, 0, 1, 0}), shp), 999))
+	assert.Equal(t, []Class{2, 0}, ToClasses(T.New(T.WithBacking([]int{0, 0, 2, 1, 2, 0}), shp), 0))
+	assert.Equal(t, []Class{0, 0}, ToClasses(T.New(T.WithBacking([]int{1, 1, 1, 1, 1, 1}), shp), 0))
+	assert.Equal(t, []Class{1, 2}, ToClasses(T.New(T.WithBacking([]int{-1, 1, -2, -3, 0, 1}), shp), 0))
 	// Uint
-	matUint = T.New(T.WithBacking([]uint{0, 0, 1, 0, 1, 0}), shp)
-	assert.Equal(t, []Class{2, 1}, ToClasses(matUint, 0))
-
-	matUint = T.New(T.WithBacking([]uint{0, 0, 1, 0, 1, 0}), shp)
-	assert.Equal(t, []Class{2, 1}, ToClasses(matUint, 999))
-
-	matUint = T.New(T.WithBacking([]uint{0, 0, 2, 1, 2, 0}), shp)
-	assert.Equal(t, []Class{2, 0}, ToClasses(matUint, 0))
-
-	matUint = T.New(T.WithBacking([]uint{1, 1, 1, 1, 1, 1}), shp)
-	assert.Equal(t, []Class{0, 0}, ToClasses(matUint, 0))
+	assert.Equal(t, []Class{2, 1}, ToClasses(T.New(T.WithBacking([]uint{0, 0, 1, 0, 1, 0}), shp), 0))
+	assert.Equal(t, []Class{2, 1}, ToClasses(T.New(T.WithBacking([]uint{0, 0, 1, 0, 1, 0}), shp), 999))
+	assert.Equal(t, []Class{2, 0}, ToClasses(T.New(T.WithBacking([]uint{0, 0, 2, 1, 2, 0}), shp), 0))
+	assert.Equal(t, []Class{0, 0}, ToClasses(T.New(T.WithBacking([]uint{1, 1, 1, 1, 1, 1}), shp), 0))
 }
 
 func NewToOneHotVectorSuite(unsafe bool, a Class, numClasses uint, backingActual, backingExpected interface{}) *ToOneHotVectorSuite {

--- a/class_test.go
+++ b/class_test.go
@@ -189,30 +189,25 @@ func TestToOneHotVectorSuite(t *testing.T) {
 	// Float32
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []float32{0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []float32{1, 1, 1, 1, 1}, []float32{0, 1, 0, 0, 0}))
-	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []float32{1, 1, 1, 1, 1}, []float32{0, 1, 0, 0, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 3, []float32{0, 0, 0}, []float32{0, 1, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 3, 5, []float32{0, 0, 0, 0, 0}, []float32{0, 0, 0, 1, 0}))
 	// Float64
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []float64{0, 0, 0, 0, 0}, []float64{0, 1, 0, 0, 0}))
-	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []float64{1, 1, 1, 1, 1}, []float64{0, 1, 0, 0, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []float64{1, 1, 1, 1, 1}, []float64{0, 1, 0, 0, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 3, []float64{0, 0, 0}, []float64{0, 1, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 3, 5, []float64{0, 0, 0, 0, 0}, []float64{0, 0, 0, 1, 0}))
 	// Int32
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int32{0, 0, 0, 0, 0}, []int32{0, 1, 0, 0, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int32{1, 1, 1, 1, 1}, []int32{0, 1, 0, 0, 0}))
-	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int32{1, 1, 1, 1, 1}, []int32{0, 1, 0, 0, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 3, []int32{0, 0, 0}, []int32{0, 1, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 3, 5, []int32{0, 0, 0, 0, 0}, []int32{0, 0, 0, 1, 0}))
 	// Int64
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int64{0, 0, 0, 0, 0}, []int64{0, 1, 0, 0, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int64{1, 1, 1, 1, 1}, []int64{0, 1, 0, 0, 0}))
-	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int64{1, 1, 1, 1, 1}, []int64{0, 1, 0, 0, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 3, []int64{0, 0, 0}, []int64{0, 1, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 3, 5, []int64{0, 0, 0, 0, 0}, []int64{0, 0, 0, 1, 0}))
 	// Int
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int{0, 0, 0, 0, 0}, []int{0, 1, 0, 0, 0}))
-	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int{1, 1, 1, 1, 1}, []int{0, 1, 0, 0, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 5, []int{1, 1, 1, 1, 1}, []int{0, 1, 0, 0, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 1, 3, []int{0, 0, 0}, []int{0, 1, 0}))
 	suite.Run(t, NewToOneHotVectorSuite(false, 3, 5, []int{0, 0, 0, 0, 0}, []int{0, 0, 0, 1, 0}))
@@ -316,5 +311,26 @@ func TestUnsafeToOneHotMatrix(t *testing.T) {
 	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1}, 5, []float32{0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0}, []int{1, 5}))
 	// Col Vector
 	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{0, 0, 0, 0, 0}, 1, []float32{0, 0, 0, 0, 0}, []float32{1, 1, 1, 1, 1}, []int{5, 1}))
-	// suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1, 1}, 5, []float32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0, 0, 1, 0, 0, 0}, []int{2, 5}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1, 1}, 3, []float32{0, 0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 1, 0}, []int{2, 3}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{2, 0}, 3, []float32{0, 0, 0, 0, 0, 0}, []float32{0, 0, 1, 1, 0, 0}, []int{2, 3}))
+	// Float64
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1}, 5, []float64{0, 0, 0, 0, 0}, []float64{0, 1, 0, 0, 0}, []int{1, 5}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{0, 0, 0, 0, 0}, 1, []float64{0, 0, 0, 0, 0}, []float64{1, 1, 1, 1, 1}, []int{5, 1}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1, 1}, 3, []float64{0, 0, 0, 0, 0, 0}, []float64{0, 1, 0, 0, 1, 0}, []int{2, 3}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{2, 0}, 3, []float64{0, 0, 0, 0, 0, 0}, []float64{0, 0, 1, 1, 0, 0}, []int{2, 3}))
+	// Int
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1}, 5, []int{0, 0, 0, 0, 0}, []int{0, 1, 0, 0, 0}, []int{1, 5}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{0, 0, 0, 0, 0}, 1, []int{0, 0, 0, 0, 0}, []int{1, 1, 1, 1, 1}, []int{5, 1}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1, 1}, 3, []int{0, 0, 0, 0, 0, 0}, []int{0, 1, 0, 0, 1, 0}, []int{2, 3}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{2, 0}, 3, []int{0, 0, 0, 0, 0, 0}, []int{0, 0, 1, 1, 0, 0}, []int{2, 3}))
+	// Int64
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1}, 5, []int64{0, 0, 0, 0, 0}, []int64{0, 1, 0, 0, 0}, []int{1, 5}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{0, 0, 0, 0, 0}, 1, []int64{0, 0, 0, 0, 0}, []int64{1, 1, 1, 1, 1}, []int{5, 1}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1, 1}, 3, []int64{0, 0, 0, 0, 0, 0}, []int64{0, 1, 0, 0, 1, 0}, []int{2, 3}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{2, 0}, 3, []int64{0, 0, 0, 0, 0, 0}, []int64{0, 0, 1, 1, 0, 0}, []int{2, 3}))
+	// Int32
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1}, 5, []int32{0, 0, 0, 0, 0}, []int32{0, 1, 0, 0, 0}, []int{1, 5}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{0, 0, 0, 0, 0}, 1, []int32{0, 0, 0, 0, 0}, []int32{1, 1, 1, 1, 1}, []int{5, 1}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1, 1}, 3, []int32{0, 0, 0, 0, 0, 0}, []int32{0, 1, 0, 0, 1, 0}, []int{2, 3}))
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{2, 0}, 3, []int32{0, 0, 0, 0, 0, 0}, []int32{0, 0, 1, 1, 0, 0}, []int{2, 3}))
 }

--- a/class_test.go
+++ b/class_test.go
@@ -16,7 +16,7 @@ func TestToClass(t *testing.T) {
 	// Panic on Unreachable
 	assert.Panics(t, func() { ToClass(T.New(T.WithBacking([]float32{0, 0, 1, 0, 0})), 999) })
 
-	// From here On only specifying vectors of length 5 varying type and threshold
+	// From here on only specifying vectors of length 5 varying type and threshold
 	// Float32
 	assert.Equal(t, ToClass(T.New(T.WithBacking([]float32{0, 0, 1, 0, 0})), 0), Class(2))
 	assert.Equal(t, ToClass(T.New(T.WithBacking([]float32{0.1, 0.1, 0.6, 0.7, 0.1})), 0), Class(2))
@@ -43,7 +43,14 @@ func TestToClass(t *testing.T) {
 }
 
 func TestToClasses(t *testing.T) {
-	// Not Implemented
+	// TODO: panic without an iterator
+	// Test panic on non matrix
+	assert.Panics(t, func() { ToClass(T.New(T.Of(T.Float32), T.WithShape(10)), 0) })
+	assert.Panics(t, func() { ToClass(T.New(T.Of(T.Float32), T.WithShape(10, 10, 10)), 0) })
+	// Panic on unsupported T dtype
+	assert.Panics(t, func() { ToClass(T.New(T.Of(T.Complex64), T.WithShape(10)), 0) })
+	// Panic on Unreachable
+	assert.Panics(t, func() { ToClass(T.New(T.WithBacking([][]float32{{0, 0, 1}, {0, 0, 1}})), 999) })
 }
 
 func TestToOneHotVector(t *testing.T) {

--- a/class_test.go
+++ b/class_test.go
@@ -169,7 +169,7 @@ func (suite *ToOneHotVectorSuite) Test() {
 	}
 }
 
-func TestToOneHotVector(t *testing.T) {
+func TestToOneHotVectorSuite(t *testing.T) {
 	// Panics
 	// n classes not the same as vector length
 	assert.Panics(t, func() { UnsafeToOneHotVector(0, 999, T.New(T.Of(T.Float32), T.WithShape(5))) })
@@ -218,7 +218,7 @@ func TestToOneHotVector(t *testing.T) {
 	suite.Run(t, NewToOneHotVectorSuite(false, 3, 5, []int{0, 0, 0, 0, 0}, []int{0, 0, 0, 1, 0}))
 }
 
-func TestToOneHotVectorSuite(t *testing.T) {
+func TestUnsafeToOneHotVectorSuite(t *testing.T) {
 	// Panics
 	// n classes not the same as vector length
 	assert.Panics(t, func() { UnsafeToOneHotVector(0, 999, T.New(T.Of(T.Float32), T.WithShape(5))) })
@@ -311,6 +311,10 @@ func TestToOneHotMatrix(t *testing.T) {
 }
 
 func TestUnsafeToOneHotMatrix(t *testing.T) {
+	// Float32
+	// Row Vector
 	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1}, 5, []float32{0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0}, []int{1, 5}))
+	// Col Vector
+	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{0, 0, 0, 0, 0}, 1, []float32{0, 0, 0, 0, 0}, []float32{1, 1, 1, 1, 1}, []int{5, 1}))
 	// suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1, 1}, 5, []float32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0, 0, 1, 0, 0, 0}, []int{2, 5}))
 }

--- a/class_test.go
+++ b/class_test.go
@@ -4,35 +4,42 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gorgonia.org/tensor"
+	T "gorgonia.org/tensor"
 )
 
 func TestToClass(t *testing.T) {
 	// TODO: panic without an iterator
 	// Test panic on non vector
-	panicOnNonVector := func() {
-		_ = ToClass(tensor.New(tensor.Of(tensor.Float32), tensor.WithShape(10, 10)), 0)
-	}
-	assert.Panics(t, panicOnNonVector)
-	// Panic on unsupported tensor dtype
-	panicOnUnsupportedType := func() {
-		_ = ToClass(tensor.New(tensor.Of(tensor.Complex64), tensor.WithShape(10)), 0)
-	}
-	assert.Panics(t, panicOnUnsupportedType)
+	assert.Panics(t, func() { ToClass(T.New(T.Of(T.Float32), T.WithShape(10, 10)), 0) })
+	// Panic on unsupported T dtype
+	assert.Panics(t, func() { ToClass(T.New(T.Of(T.Complex64), T.WithShape(10)), 0) })
+	// Panic on Unreachable
+	assert.Panics(t, func() { ToClass(T.New(T.WithBacking([]float32{0, 0, 1, 0, 0})), 999) })
 
-	// // Float32
-	// dataFloat32 := []float32{0, 0, 1, 0, 0}
-	// resultFloat32 := ToClass(tensor.New(tensor.WithBacking(dataFloat32)), 0)
-	// assert.Equal(t, resultFloat32, Class(2))
-
-	// dataFloat64 := []float64{0, 1, 2, 3, 4}
-	// t.Log(ToClass(tensor.New(tensor.WithBacking(dataFloat64)), 0))
-
-	// dataInt := []int{0, 1, 2, 3, 4}
-	// t.Log(ToClass(tensor.New(tensor.WithBacking(dataInt)), 0))
-
-	// dataUint := []uint{0, 1, 2, 3, 4}
-	// t.Log(ToClass(tensor.New(tensor.WithBacking(dataUint)), 0))
+	// From here On only specifying vectors of length 5 varying type and threshold
+	// Float32
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]float32{0, 0, 1, 0, 0})), 0), Class(2))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]float32{0.1, 0.1, 0.6, 0.7, 0.1})), 0), Class(2))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]float32{0.1, 0.1, 0.6, 0.7, 0.1})), 0.65), Class(3))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]float32{1, 1, 1, 1, 1})), 0), Class(0))
+	// Float64
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]float64{0, 0, 1, 0, 0})), 0), Class(2))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]float64{0.1, 0.1, 0.6, 0.7, 0.1})), 0), Class(2))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]float64{0.1, 0.1, 0.6, 0.7, 0.1})), 0.65), Class(3))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]float64{1, 1, 1, 1, 1})), 0), Class(0))
+	// Int
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]int{0, 0, 1, 0, 0})), 0), Class(2))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]int{0, 0, 1, 0, 0})), 999), Class(2))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]int{0, 0, 2, 0, 0})), 0), Class(2))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]int{0, 1, 2, 0, 0})), 0), Class(1))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]int{1, 1, 1, 1, 1})), 0), Class(0))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]int{-1, -2, -3, 0, 1})), 0), Class(4))
+	// uint
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]uint{0, 0, 1, 0, 0})), 0), Class(2))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]uint{0, 0, 1, 0, 0})), 999), Class(2))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]uint{0, 0, 2, 0, 0})), 0), Class(2))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]uint{0, 1, 2, 0, 0})), 0), Class(1))
+	assert.Equal(t, ToClass(T.New(T.WithBacking([]uint{1, 1, 1, 1, 1})), 0), Class(0))
 }
 
 func TestToClasses(t *testing.T) {

--- a/class_test.go
+++ b/class_test.go
@@ -302,7 +302,39 @@ func (suite *ToOneHotMatrixSuite) Test() {
 }
 
 func TestToOneHotMatrix(t *testing.T) {
-	// Not Implemented
+	// Panic tests
+	// Unsupported type
+	assert.Panics(t, func() { ToOneHotMatrix([]Class{1, 1, 1, 1, 1}, 5, T.Complex64) })
+	assert.NotPanics(t, func() { ToOneHotMatrix([]Class{1, 1, 1, 1, 1}, 5, T.Float32) })
+
+	// Value tests
+	// Float32
+	// Row Vector
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{1}, 5, []float32{0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0}, []int{1, 5}))
+	// Col Vector
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{0, 0, 0, 0, 0}, 1, []float32{0, 0, 0, 0, 0}, []float32{1, 1, 1, 1, 1}, []int{5, 1}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{1, 1}, 3, []float32{0, 0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 1, 0}, []int{2, 3}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{2, 0}, 3, []float32{0, 0, 0, 0, 0, 0}, []float32{0, 0, 1, 1, 0, 0}, []int{2, 3}))
+	// Float64
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{1}, 5, []float64{0, 0, 0, 0, 0}, []float64{0, 1, 0, 0, 0}, []int{1, 5}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{0, 0, 0, 0, 0}, 1, []float64{0, 0, 0, 0, 0}, []float64{1, 1, 1, 1, 1}, []int{5, 1}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{1, 1}, 3, []float64{0, 0, 0, 0, 0, 0}, []float64{0, 1, 0, 0, 1, 0}, []int{2, 3}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{2, 0}, 3, []float64{0, 0, 0, 0, 0, 0}, []float64{0, 0, 1, 1, 0, 0}, []int{2, 3}))
+	// Int
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{1}, 5, []int{0, 0, 0, 0, 0}, []int{0, 1, 0, 0, 0}, []int{1, 5}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{0, 0, 0, 0, 0}, 1, []int{0, 0, 0, 0, 0}, []int{1, 1, 1, 1, 1}, []int{5, 1}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{1, 1}, 3, []int{0, 0, 0, 0, 0, 0}, []int{0, 1, 0, 0, 1, 0}, []int{2, 3}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{2, 0}, 3, []int{0, 0, 0, 0, 0, 0}, []int{0, 0, 1, 1, 0, 0}, []int{2, 3}))
+	// Int64
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{1}, 5, []int64{0, 0, 0, 0, 0}, []int64{0, 1, 0, 0, 0}, []int{1, 5}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{0, 0, 0, 0, 0}, 1, []int64{0, 0, 0, 0, 0}, []int64{1, 1, 1, 1, 1}, []int{5, 1}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{1, 1}, 3, []int64{0, 0, 0, 0, 0, 0}, []int64{0, 1, 0, 0, 1, 0}, []int{2, 3}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{2, 0}, 3, []int64{0, 0, 0, 0, 0, 0}, []int64{0, 0, 1, 1, 0, 0}, []int{2, 3}))
+	// Int32
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{1}, 5, []int32{0, 0, 0, 0, 0}, []int32{0, 1, 0, 0, 0}, []int{1, 5}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{0, 0, 0, 0, 0}, 1, []int32{0, 0, 0, 0, 0}, []int32{1, 1, 1, 1, 1}, []int{5, 1}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{1, 1}, 3, []int32{0, 0, 0, 0, 0, 0}, []int32{0, 1, 0, 0, 1, 0}, []int{2, 3}))
+	suite.Run(t, NewToOneHotMatrixSuite(false, []Class{2, 0}, 3, []int32{0, 0, 0, 0, 0, 0}, []int32{0, 0, 1, 1, 0, 0}, []int{2, 3}))
 }
 
 func TestUnsafeToOneHotMatrix(t *testing.T) {

--- a/class_test.go
+++ b/class_test.go
@@ -79,15 +79,53 @@ func TestToClasses(t *testing.T) {
 	assert.Equal(t, ToClasses(matF32, 0), []Class{0, 0})
 
 	// Float64
+	// chewxy testcase
+	matF64 = T.New(T.WithBacking([]float64{0.1, 0.1, 0.6, 0.7, 0.1, 0.6, 0.1, 0.1, 0.7, 0.1}), T.WithShape(2, 5))
+	assert.Equal(t, ToClasses(matF64, 0), []Class{2, 0})
+
 	matF64 = T.New(T.WithBacking([]float64{0, 0, 1, 0, 1, 0}), shp)
 	assert.Equal(t, ToClasses(matF64, 0), []Class{2, 1})
+
+	matF64 = T.New(T.WithBacking([]float64{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp)
+	assert.Equal(t, ToClasses(matF64, 0), []Class{1, 1})
+
+	matF64 = T.New(T.WithBacking([]float64{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp)
+	assert.Equal(t, ToClasses(matF64, 0.65), []Class{2, 1})
+
+	matF64 = T.New(T.WithBacking([]float64{0.1, -1, 0.7, -1.0, 0.2, 0.6}), shp)
+	assert.Equal(t, ToClasses(matF64, 0), []Class{2, 2})
+
+	matF64 = T.New(T.WithBacking([]float64{1, 1, 1, 1, 1, 1}), shp)
+	assert.Equal(t, ToClasses(matF64, 0), []Class{0, 0})
 
 	// Int
 	matInt = T.New(T.WithBacking([]int{0, 0, 1, 0, 1, 0}), shp)
 	assert.Equal(t, ToClasses(matInt, 0), []Class{2, 1})
+
+	matInt = T.New(T.WithBacking([]int{0, 0, 1, 0, 1, 0}), shp)
+	assert.Equal(t, ToClasses(matInt, 999), []Class{2, 1})
+
+	matInt = T.New(T.WithBacking([]int{0, 0, 2, 1, 2, 0}), shp)
+	assert.Equal(t, ToClasses(matInt, 0), []Class{2, 0})
+
+	matInt = T.New(T.WithBacking([]int{1, 1, 1, 1, 1, 1}), shp)
+	assert.Equal(t, ToClasses(matInt, 0), []Class{0, 0})
+
+	matInt = T.New(T.WithBacking([]int{-1, 1, -2, -3, 0, 1}), shp)
+	assert.Equal(t, ToClasses(matInt, 0), []Class{1, 2})
+
 	// Uint
 	matUint = T.New(T.WithBacking([]uint{0, 0, 1, 0, 1, 0}), shp)
 	assert.Equal(t, ToClasses(matUint, 0), []Class{2, 1})
+
+	matUint = T.New(T.WithBacking([]uint{0, 0, 1, 0, 1, 0}), shp)
+	assert.Equal(t, ToClasses(matUint, 999), []Class{2, 1})
+
+	matUint = T.New(T.WithBacking([]uint{0, 0, 2, 1, 2, 0}), shp)
+	assert.Equal(t, ToClasses(matUint, 0), []Class{2, 0})
+
+	matUint = T.New(T.WithBacking([]uint{1, 1, 1, 1, 1, 1}), shp)
+	assert.Equal(t, ToClasses(matUint, 0), []Class{0, 0})
 }
 
 func TestToOneHotVector(t *testing.T) {

--- a/class_test.go
+++ b/class_test.go
@@ -53,24 +53,40 @@ func TestToClasses(t *testing.T) {
 	// Panic on unsupported T dtype
 	assert.Panics(t, func() { ToClasses(T.New(T.Of(T.Complex64), T.WithShape(10)), 0) })
 	// Panic on Unreachable
-	assert.Panics(t, func() { ToClasses(T.New(T.WithBacking([][]float32{{0, 0, 1}, {0, 0, 1}})), 999) })
+	assert.Panics(t, func() { ToClasses(T.New(T.WithBacking([]float32{0, 0, 1, 0, 0, 1}), T.WithShape(2, 3)), 999) })
 	// Value Tests
 	// only specifying matracies of length 2x3 varying values, type, and threshold
 	var matF32, matF64, matInt, matUint tensor.Tensor
+	shp := T.WithShape(2, 3)
 	// Float32
-	// []float32{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}
-	// []float32{0.1, 0.6, 0.7, -1.0, 0.2, 0.6}
-	// []float32{0.1, 0.6, 0.7, -1.0, 0.2, 0.6}
-	matF32 = T.New(T.WithBacking([]float32{0, 0, 1, 0, 1, 0}), T.WithShape(2, 3))
+	// chewxy testcase
+	matF32 = T.New(T.WithBacking([]float32{0.1, 0.1, 0.6, 0.7, 0.1, 0.6, 0.1, 0.1, 0.7, 0.1}), T.WithShape(2, 5))
+	assert.Equal(t, ToClasses(matF32, 0), []Class{2, 0})
+
+	matF32 = T.New(T.WithBacking([]float32{0, 0, 1, 0, 1, 0}), shp)
 	assert.Equal(t, ToClasses(matF32, 0), []Class{2, 1})
+
+	matF32 = T.New(T.WithBacking([]float32{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp)
+	assert.Equal(t, ToClasses(matF32, 0), []Class{1, 1})
+
+	matF32 = T.New(T.WithBacking([]float32{0.1, 0.6, 0.7, 0.1, 0.7, 0.6}), shp)
+	assert.Equal(t, ToClasses(matF32, 0.65), []Class{2, 1})
+
+	matF32 = T.New(T.WithBacking([]float32{0.1, -1, 0.7, -1.0, 0.2, 0.6}), shp)
+	assert.Equal(t, ToClasses(matF32, 0), []Class{2, 2})
+
+	matF32 = T.New(T.WithBacking([]float32{1, 1, 1, 1, 1, 1}), shp)
+	assert.Equal(t, ToClasses(matF32, 0), []Class{0, 0})
+
 	// Float64
-	matF64 = T.New(T.WithBacking([]float64{0, 0, 1, 0, 1, 0}), T.WithShape(2, 3))
+	matF64 = T.New(T.WithBacking([]float64{0, 0, 1, 0, 1, 0}), shp)
 	assert.Equal(t, ToClasses(matF64, 0), []Class{2, 1})
+
 	// Int
-	matInt = T.New(T.WithBacking([]int{0, 0, 1, 0, 1, 0}), T.WithShape(2, 3))
+	matInt = T.New(T.WithBacking([]int{0, 0, 1, 0, 1, 0}), shp)
 	assert.Equal(t, ToClasses(matInt, 0), []Class{2, 1})
 	// Uint
-	matUint = T.New(T.WithBacking([]uint{0, 0, 1, 0, 1, 0}), T.WithShape(2, 3))
+	matUint = T.New(T.WithBacking([]uint{0, 0, 1, 0, 1, 0}), shp)
 	assert.Equal(t, ToClasses(matUint, 0), []Class{2, 1})
 }
 

--- a/class_test.go
+++ b/class_test.go
@@ -306,6 +306,24 @@ func TestToOneHotMatrix(t *testing.T) {
 }
 
 func TestUnsafeToOneHotMatrix(t *testing.T) {
+	// Panic tests
+	// Non Matrix
+	assert.Panics(t, func() { UnsafeToOneHotMatrix([]Class{1}, 5, T.New(T.Of(T.Float32), T.WithShape(5))) })
+	assert.Panics(t, func() { UnsafeToOneHotMatrix([]Class{1, 1, 1, 1, 1}, 5, T.New(T.Of(T.Float32), T.WithShape(5, 5, 5))) })
+	assert.NotPanics(t, func() { UnsafeToOneHotMatrix([]Class{1, 1, 1, 1, 1}, 5, T.New(T.Of(T.Float32), T.WithShape(5, 5))) })
+	// Wrong number of classes (rows)
+	assert.Panics(t, func() { UnsafeToOneHotMatrix([]Class{1, 1, 1, 1, 1, 1}, 5, T.New(T.Of(T.Float32), T.WithShape(5, 5))) })
+	assert.Panics(t, func() { UnsafeToOneHotMatrix([]Class{1, 1, 1, 1}, 5, T.New(T.Of(T.Float32), T.WithShape(5, 5))) })
+	assert.NotPanics(t, func() { UnsafeToOneHotMatrix([]Class{1, 1, 1, 1, 1}, 5, T.New(T.Of(T.Float32), T.WithShape(5, 5))) })
+	// Wrong number of classes (cols)
+	assert.Panics(t, func() { UnsafeToOneHotMatrix([]Class{1, 1, 1, 1, 1}, 4, T.New(T.Of(T.Float32), T.WithShape(5, 5))) })
+	assert.Panics(t, func() { UnsafeToOneHotMatrix([]Class{1, 1, 1, 1, 1}, 6, T.New(T.Of(T.Float32), T.WithShape(5, 5))) })
+	assert.NotPanics(t, func() { UnsafeToOneHotMatrix([]Class{1, 1, 1, 1, 1}, 5, T.New(T.Of(T.Float32), T.WithShape(5, 5))) })
+	// Unsupported type
+	assert.Panics(t, func() { UnsafeToOneHotMatrix([]Class{1, 1, 1, 1, 1}, 5, T.New(T.Of(T.Complex64), T.WithShape(5, 5))) })
+	assert.NotPanics(t, func() { UnsafeToOneHotMatrix([]Class{1, 1, 1, 1, 1}, 5, T.New(T.Of(T.Float32), T.WithShape(5, 5))) })
+
+	// Value tests
 	// Float32
 	// Row Vector
 	suite.Run(t, NewToOneHotMatrixSuite(true, []Class{1}, 5, []float32{0, 0, 0, 0, 0}, []float32{0, 1, 0, 0, 0}, []int{1, 5}))

--- a/nodes.go
+++ b/nodes.go
@@ -8,13 +8,13 @@ import (
 // nodes creates new nodes. This will definitely change over time.
 
 // OneHotVector creates a node that represents a one-hot vector.
-func OneHotVector(a Class, numClasses int, dtype tensor.Dtype, opts ...G.NodeConsOpt) *G.Node {
+func OneHotVector(a Class, numClasses uint, dtype tensor.Dtype, opts ...G.NodeConsOpt) *G.Node {
 	ohv := ToOneHotVector(a, numClasses, dtype)
 	return G.NewConstant(ohv, opts...)
 }
 
 // OneHotMatrix creates a node that represents a one-hot matrix.
-func OneHotMatrix(a []Class, numClasses int, dtype tensor.Dtype, opts ...G.NodeConsOpt) *G.Node {
+func OneHotMatrix(a []Class, numClasses uint, dtype tensor.Dtype, opts ...G.NodeConsOpt) *G.Node {
 	ohm := ToOneHotMatrix(a, numClasses, dtype)
 	return G.NewConstant(ohm, opts...)
 }


### PR DESCRIPTION
- Created tests for all of the functions in class.go
- Changed continues in ToClasses to breaks in order to get the first-class above the specified threshold
- Added an unreachable panic in ToClasses for a given row in matrix
- Changed numClasses to be uint
- UnsafeOneHotMatrix checks for if the dimensions of the matrix satisfy the number of classes and the length of the Class  slice  provided before iterations over said Class slice
- Dealt with RowVec edge case in UnsafeOneHotMatrix